### PR TITLE
Support Linux 6.4

### DIFF
--- a/bt.c
+++ b/bt.c
@@ -135,7 +135,11 @@ static void wilc_bt_create_device(void)
 	ret = alloc_chrdev_region(&chc_dev_no, 0, 1, "atmel");
 	if (ret < 0)
 		return;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+	chc_dev_class = class_create("atmel");
+#else
 	chc_dev_class = class_create(THIS_MODULE, "atmel");
+#endif
 	if (IS_ERR(chc_dev_class)) {
 		unregister_chrdev_region(chc_dev_no, 1);
 		return;


### PR DESCRIPTION
With Linux 6.4 commit:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1aaba11da9aa7d7d6b52a74d45b31cac118295a1 class_create() doesn't require first argument THIS_MODULE anymore so let's drop first argument if Linux version >= 6.4